### PR TITLE
feat(tap): Tap `homebrew/core` if `tap` is empty

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -74,11 +74,12 @@ module Homebrew
   git 'config', '--global', 'user.name', user_name
   git 'config', '--global', 'user.email', user_email
 
-  # Always tap homebrew/core, otherwise brew can't find formulae
-  brew 'tap', 'homebrew/core'
-  
-  # Tap the requested tap if applicable
-  brew 'tap', tap unless tap.blank?
+  if tap.blank?
+    brew 'tap', 'homebrew/core', '--force'
+  else
+    # Tap the requested tap if applicable
+    brew 'tap', tap
+  end
 
   # Append additional PR message
   message = if message.blank?


### PR DESCRIPTION
To make the operation faster.
Also, add the `--force` option to run correctly.
fix: #59 