### PR TITLE
Allow editing the Git user name and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The Action will extract all needed informations by itself, you just need to spec
   with:
     # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
     token: ${{secrets.TOKEN}}
+    # Optional, will commit with this user name
+    user_name: name
+    # Optional, will commit with this user email
+    user_email: email@example.com
     # Optional, will create tap repo fork in organization
     org: ORG
     # Optional, use the origin repository instead of forking
@@ -61,6 +65,10 @@ If there are no outdated formulae, the Action will just exit.
   with:
     # Required, custom personal GitHub access token with only the 'public_repo' scope enabled
     token: ${{secrets.CUSTOM_PERSONAL_ACCESS_TOKEN}}
+    # Optional, will commit with this user name
+    user_name: user_name
+    # Optional, will commit with this user email
+    user_email: email@example.com
     # Optional, will create tap repo fork in organization
     org: ORG
     # Bump all outdated formulae in this tap

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ inputs:
   token:
     description: GitHub token (not the default one)
     required: true
+  user_name:
+    description: Git user name to commit by.
+    required: false
+  user_email:
+    description: Git user email to commit by.
+    required: false
   message:
     description: |
       Additional message to append to created PR.
@@ -83,6 +89,8 @@ runs:
       shell: sh
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
+        HOMEBREW_GIT_NAME: ${{inputs.user_name}}
+        HOMEBREW_GIT_EMAIL: ${{inputs.user_email}}
         HOMEBREW_BUMP_MESSAGE: ${{inputs.message}}
         HOMEBREW_BUMP_ORG: ${{inputs.org}}
         HOMEBREW_BUMP_NO_FORK: ${{inputs.no_fork}}

--- a/main.rb
+++ b/main.rb
@@ -40,6 +40,8 @@ module Homebrew
 
   # Get inputs
   message = ENV['HOMEBREW_BUMP_MESSAGE']
+  user_name = ENV['HOMEBREW_GIT_NAME']
+  user_email = ENV['HOMEBREW_GIT_EMAIL']
   org = ENV['HOMEBREW_BUMP_ORG']
   no_fork = ENV['HOMEBREW_BUMP_NO_FORK']
   tap = ENV['HOMEBREW_BUMP_TAP']
@@ -59,7 +61,7 @@ module Homebrew
   user = GitHub::API.open_rest "#{GitHub::API_URL}/user"
   user_id = user['id']
   user_login = user['login']
-  user_name = user['name'] || user['login']
+  user_name = user['name'] || user['login'] if user_name.blank?
   user_email = user['email'] || (
     # https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address
     user_created_at = Date.parse user['created_at']
@@ -68,7 +70,7 @@ module Homebrew
     user_email = "#{user_login}@users.noreply.github.com"
     user_email = "#{user_id}+#{user_email}" if need_plus_email
     user_email
-  )
+  ) if user_email.blank?
 
   # Tell git who you are
   git 'config', '--global', 'user.name', user_name


### PR DESCRIPTION
If you specify user_name and user_email, commits will operated by that user.

```yaml
- uses: uses: dawidd6/action-homebrew-bump-formula@v3
  with:
    user_name: user_name
    user_email: email@example.com
```

closes: #58