### PR TITLE
prefer to use `released` event than `created`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Listen for new tags in workflow:
 on:
   # trigger when release got created (preferred)
   release:
-    types: [created]
+    types: [released]
   # trigger on tag push
   # push:
   #   tags:


### PR DESCRIPTION
quick followup #64 (was just about to amend that PR 😅 ).

released event is better than created, as it would avoid both draft release as well as pre-release events. 

![image](https://github.com/dawidd6/action-homebrew-bump-formula/assets/1580956/fc164038-df36-4119-8d42-c69e78e4796d)

![image](https://github.com/dawidd6/action-homebrew-bump-formula/assets/1580956/dc72fa19-3372-46e7-bb0c-2432a47dc255)


Thanks @dawidd6! 🙏  