### PR TITLE
Do not query the GitHub API unnecessarily

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -58,20 +58,25 @@ module Homebrew
     odie "Need 'tag' input specified" if tag.blank?
   end
 
-  # Get user details
-  user = GitHub::API.open_rest "#{GitHub::API_URL}/user"
-  user_id = user['id']
-  user_login = user['login']
-  user_name = user['name'] || user['login'] if user_name.blank?
-  user_email = user['email'] || (
-    # https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address
-    user_created_at = Date.parse user['created_at']
-    plus_after_date = Date.parse '2017-07-18'
-    need_plus_email = (user_created_at - plus_after_date).positive?
-    user_email = "#{user_login}@users.noreply.github.com"
-    user_email = "#{user_id}+#{user_email}" if need_plus_email
-    user_email
-  ) if user_email.blank?
+  # Avoid using the GitHub API whenever possible.
+  # This helps users who use application tokens instead of personal access tokens.
+  # Application tokens don't work with GitHub API's `/user` endpoit.
+  if user_name.blank? && user_email.blank?
+    # Get user details
+    user = GitHub::API.open_rest "#{GitHub::API_URL}/user"
+    user_id = user['id']
+    user_login = user['login']
+    user_name = user['name'] || user['login'] if user_name.blank?
+    user_email = user['email'] || (
+      # https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address
+      user_created_at = Date.parse user['created_at']
+      plus_after_date = Date.parse '2017-07-18'
+      need_plus_email = (user_created_at - plus_after_date).positive?
+      user_email = "#{user_login}@users.noreply.github.com"
+      user_email = "#{user_id}+#{user_email}" if need_plus_email
+      user_email
+    ) if user_email.blank?
+  end
 
   # Tell git who you are
   git 'config', '--global', 'user.name', user_name


### PR DESCRIPTION
This could help users who need to use Application tokens for the GitHub API. The only thing I'm not sure about is whether it's ok to use an application token in `HOMEBREW_GITHUB_API_TOKEN`. I think it is, based on some old builds that I found.

Note that I haven't tested this end to end yet. I ran it for the Grafana Alloy repo, but since it's already on the latest release I get this error from Homebrew:

```
==> Tapping grafana/grafana
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/grafana/homebrew-grafana'...
Tapped 6 formulae (21 files, 245.3KB).
/home/linuxbrew/.linuxbrew/bin/brew bump-formula-pr --no-audit --no-browse --message=[`action-homebrew-bump-formula`](https://github.com/dawidd6/action-homebrew-bump-formula) --version=1.8.1 grafana/grafana/alloy
Warning: These  pull requests are duplicates:
Update alloy formula for 1.8.1 https://github.com/grafana/homebrew-grafana/pull/120

Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/grafana/alloy/archive/refs/tags/v1.8.1.tar.gz

/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/kernel.rb:2[84](https://github.com/grafana/alloy/actions/runs/14593580534/job/40934134733?pr=3340#step:6:89):in `safe_system': Failure while executing; `/home/linuxbrew/.linuxbrew/bin/brew bump-formula-pr --no-audit --no-browse --message=\[\`action-homebrew-bump-formula\`\]\(https://github.com/dawidd6/action-homebrew-bump-formula\) --version=1.8.1 grafana/grafana/alloy` exited with 1. (ErrorDuringExecution)
	from /home/runner/work/_actions/ptodev/action-homebrew-bump-formula/master/main.rb:26:in `brew'
	from /home/runner/work/_actions/ptodev/action-homebrew-bump-formula/master/main.rb:119:in `<module:Homebrew>'
	from /home/runner/work/_actions/ptodev/action-homebrew-bump-formula/master/main.rb:17:in `<main>'
Error: Process completed with exit code 1.
```

Fixes #66