### PR TITLE
Fix compatibility with Homebrew 5.0

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -15,6 +15,7 @@ class String
 end
 
 module Homebrew
+  extend Utils::Output::Mixin
   module_function
 
   def print_command(*cmd)


### PR DESCRIPTION
Fixes #100

## Problem

The action fails with Homebrew 5.0.x due to an undefined method error:
```
undefined method 'odie' for module Homebrew (NoMethodError)
```

## Root Cause

Homebrew 5.0 changed how internal Ruby APIs are loaded. The `odie` method (and other output utilities) are defined in `Utils::Output::Mixin` but are no longer automatically available in all module contexts.

## Solution

Explicitly extend `Utils::Output::Mixin` in the `Homebrew` module on line 18 of `main.rb`. This makes the output methods (`odie`, `opoo`, etc.) available as module methods.

## Changes

- Added single line: `extend Utils::Output::Mixin` after `module Homebrew`

## Compatibility

This fix maintains backward compatibility with Homebrew 4.x while supporting 5.0+. Using `extend` instead of `include` ensures the methods work as module functions, which matches how the code calls them (e.g., `odie output`).

## Testing

Verified locally that the `odie` method is now accessible:
```bash
brew ruby -e "module Homebrew; extend Utils::Output::Mixin; module_function; end; Homebrew.odie 'test'"
# Error: test (exits with code 1)
```

The existing integration tests in `.github/workflows/test.yml` will validate this works end-to-end with Homebrew 5.0.

## Evidence

- **Last successful run**: [#19465625317](https://github.com/sheurich/homebrew-tap/actions/runs/19465625317) (2025-11-18, no updates found, bump-formula-pr not executed)
- **First failing run**: [#19485089838](https://github.com/sheurich/homebrew-tap/actions/runs/19485089838) (2025-11-19, Homebrew 5.0.x)