### PR TITLE
Trust tapped repositories before formula load

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -88,6 +88,7 @@ module Homebrew
   else
     # Tap the requested tap if applicable
     brew 'tap', tap, *(tap_url unless tap_url.blank?)
+    brew 'trust', tap
   end
 
   # Append additional PR message


### PR DESCRIPTION
## Summary
- Trust the requested tap after running `brew tap`
- Prevent Homebrew from raising `UntrustedTapError` when loading formulas from third-party taps

## Testing
- `ruby -c main.rb`